### PR TITLE
Specify version for module source in main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,6 +34,7 @@ module "serverless" {
 module "serverless_xray" {
   // source = "../../terraform-aws-serverless/modules/xray" // DEV ONLY
   source = "FormidableLabs/serverless/aws//modules/xray"
+  version = "0.2.3"
 
   # Same variables as for `serverless` module.
   region       = "${var.region}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,6 +12,7 @@ terraform {
 module "serverless" {
   // source = "../../terraform-aws-serverless" // DEV ONLY
   source = "FormidableLabs/serverless/aws"
+  version = "0.2.3"
 
   region       = "${var.region}"
   service_name = "${var.service_name}"


### PR DESCRIPTION
Per [the docs](https://www.terraform.io/docs/configuration/modules.html#module-versions):

> We recommend explicitly constraining the acceptable version numbers for each external module to avoid unexpected or unwanted changes.