### PR TITLE
Misc: documentation updates + bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ The following commands need extra command support:
 
 * `yarn tf:service:apply`
 * `yarn tf:service:_delete`
+* `yarn lambda:deploy`
 
 We have a [research ticket](https://github.com/FormidableLabs/aws-lambda-serverless-reference/issues/38) to better handle sessions with MFA, but in the meantime you can simply add the `--no-session` flag to any `aws-vault` commands that need it. E.g.
 
@@ -439,6 +440,9 @@ is required (to effect the underlying CloudFormation changes).
 ```sh
 $ STAGE=sandbox yarn run lambda:deploy
 
+# **WARNING**: If using `aws-vault`, remember `--no-session`!
+$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- STAGE=sandbox yarn lambda:deploy
+
 # Check on app and endpoints.
 $ STAGE=sandbox yarn run lambda:info
 ```
@@ -498,6 +502,9 @@ https://console.aws.amazon.com/cloudwatch/home?#logStream:group=/aws/lambda/sls-
 
 ```sh
 $ STAGE=sandbox yarn run lambda:deploy
+
+# **WARNING**: If using `aws-vault`, remember `--no-session`!
+$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- STAGE=sandbox yarn lambda:deploy
 ```
 
 **Rollback** to a previous Lambda deployment:

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ $ STAGE=sandbox aws-vault exec FIRST.LAST -- yarn run lambda:info
 
 > ⚠️ **Warning**: Certain IAM role creation commands do not work with the default `aws-vault` setup if you have MFA set up (which you should).
 
-The following commands need extra command support:
+The following commands that definitely need extra command support:
 
 * `yarn tf:service:apply`
 * `yarn tf:service:_delete`
@@ -258,9 +258,13 @@ The following commands need extra command support:
 We have a [research ticket](https://github.com/FormidableLabs/aws-lambda-serverless-reference/issues/38) to better handle sessions with MFA, but in the meantime you can simply add the `--no-session` flag to any `aws-vault` commands that need it. E.g.
 
 ```sh
-# Execute a command with temporary creds
+$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- <ACTUAL_COMMAND>
+
+# E.g.
 $ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- STAGE=sandbox yarn tf:service:apply
 ```
+
+In practice, it is probably easier in the meantime to just always add the `--no-session` flag when using `aws-vault exec`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,21 @@ Enter Access Key Id: INSERT
 Enter Secret Key: INSERT
 
 # Execute a command with temporary creds
-$ aws-vault exec FIRST.LAST -- STAGE=sandbox yarn run lambda:info
+$ STAGE=sandbox aws-vault exec FIRST.LAST -- yarn run lambda:info
+```
+
+> ⚠️ **Warning**: Certain IAM role creation commands do not work with the default `aws-vault` setup if you have MFA set up (which you should).
+
+The following commands need extra command support:
+
+* `yarn tf:service:apply`
+* `yarn tf:service:_delete`
+
+We have a [research ticket](https://github.com/FormidableLabs/aws-lambda-serverless-reference/issues/38) to better handle sessions with MFA, but in the meantime you can simply add the `--no-session` flag to any `aws-vault` commands that need it. E.g.
+
+```sh
+# Execute a command with temporary creds
+$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- STAGE=sandbox yarn tf:service:apply
 ```
 
 ## Development
@@ -373,6 +387,9 @@ $ STAGE=sandbox yarn run tf:service:apply
 
 # YOLO: run without checking first
 $ STAGE=sandbox yarn run tf:service:apply -auto-approve
+
+# **WARNING**: If using `aws-vault`, remember `--no-session`!
+$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- STAGE=sandbox yarn tf:service:apply
 ```
 
 **Delete** the Terraform stack:
@@ -386,6 +403,9 @@ $ STAGE=sandbox yarn run tf:service:_delete
 
 # YOLO: run without checking first
 $ STAGE=sandbox yarn run tf:service:_delete -auto-approve
+
+# **WARNING**: If using `aws-vault`, remember `--no-session`!
+$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- STAGE=sandbox yarn tf:service:_delete
 ```
 
 **Visualize** the Terraform stack:

--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ This needs to be run once to be able to run any other Terraform commands.
 $ STAGE=sandbox yarn run tf:service:init
 ```
 
+> ⚠️ **Warning**: You need to run `yarn run tf:service:init` **every** time you change `STAGE` or other core environmental setup before you can mutate anything with the stack (like `yarn run tf:service:apply`). Failure to do so will result in bad things like incorrect stage variables applied to an old, stale stage in the underlying Terraform local disk cache.
+
 **Plan** the Terraform stack.
 
 Terraform allows you to see what's going to happen / change in your cloud infrastructure before actually committing to it, so it is _always_ a good idea to run a plan before any Terraform mutating command.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,7 +13,7 @@ terraform {
 ###############################################################################
 module "serverless" {
   source  = "FormidableLabs/serverless/aws"
-  version = "0.7.0"
+  version = "0.8.4"
 
   region       = "${var.region}"
   service_name = "${var.service_name}"
@@ -50,7 +50,7 @@ module "serverless" {
 ###############################################################################
 module "serverless_xray" {
   source  = "FormidableLabs/serverless/aws//modules/xray"
-  version = "0.7.0"
+  version = "0.8.4"
 
   # Same variables as for `serverless` module.
   region       = "${var.region}"
@@ -185,7 +185,7 @@ STACK
 # OPTION(vpc): Add in IAM permissions to humans + lambda execution role.
 module "serverless_vpc" {
   source  = "FormidableLabs/serverless/aws//modules/vpc"
-  version = "0.7.0"
+  version = "0.8.4"
 
   # Same variables as for `serverless` module.
   region       = "${var.region}"
@@ -254,7 +254,7 @@ STACK
 # OPTION(canary): Add serverless-plugin-canary-deployments to lambda execution roles.
 module "serverless_canary" {
   source  = "FormidableLabs/serverless/aws//modules/canary"
-  version = "0.7.0"
+  version = "0.8.4"
 
   # Same variables as for `serverless` module.
   region       = "${var.region}"


### PR DESCRIPTION
## Work
- Add warning have to re-initialize terraform when switching stages. #35 
- Add notes and warnings about aws-vault + IAM + MFA stuff. Adds note about #38 future work
- Update `terrraform-aws-serverless` to fix deploys. Fixes #40 , #39 

## Sandbox Environment
I have now manually deleted the existing SLS + TF `sandbox` environments as they were compromised. Then I recreated both with the following:

```sh
# Re-init sandbox stage in local state as superadmin.
$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- \
  yarn tf:service:init

# Create sandbox TF stack as superadmin.
$ STAGE=sandbox aws-vault exec FIRST.LAST --no-session -- \
  yarn tf:service:apply

# Create sandbox SLS as `-admin`
$ STAGE=sandbox aws-vault exec FIRST.LAST-admin --no-session -- \
  yarn lambda:deploy

# Re-deploy existing sandbox SLS as `-developer`
$ STAGE=sandbox aws-vault exec FIRST.LAST-developer --no-session -- \
  yarn lambda:deploy
```