### PR TITLE
Use AllAtOnce for canary and add canary docs

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -114,6 +114,7 @@ functions:
       - http: ANY /canary
       - http: 'ANY /canary/{proxy+}'
     deploymentSettings:
+      # See all options here: https://github.com/davidgf/serverless-plugin-canary-deployments#configuration
       type: AllAtOnce
       alias: Live
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -101,14 +101,20 @@ functions:
 
   #############################################################################
   # OPTION(canary): Canary-deployed Lambda using serverless-plugin-canary-deployments
-  ############################################################################
+  # To watch the canary deploy's progress for the sandbox environment, view its
+  # CodeDeploy project here:
+  # https://us-east-1.console.aws.amazon.com/codesuite/codedeploy/applications/sls-simple-reference-sandbox-SlssimplereferencesandboxDeploymentApplication-LI2MS1UTYKZT?region=us-east-1
+  #
+  # To view canary progress for other stages, find them in CodeDeploy Applications:
+  # https://us-east-1.console.aws.amazon.com/codesuite/codedeploy/applications?region=us-east-1
+  #############################################################################
   canary:
     handler: src/server/base.handler
     events: # Use a generic proxy to allow Express app to route.
       - http: ANY /canary
       - http: 'ANY /canary/{proxy+}'
     deploymentSettings:
-      type: Canary10Percent5Minutes
+      type: AllAtOnce
       alias: Live
 
   #############################################################################


### PR DESCRIPTION
- Uses `AllAtOnce` for the canary deployment settings so we don't have to wait five minutes for the gradual cutover (cool in a real app, annoying when iterating on this one!)
- Adds some inline docs and links on where to view canary deployment progress