### PR TITLE
Feature: jetpack trace mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "nodemon": "^2.0.2",
     "serverless": "^1.61.1",
-    "serverless-jetpack": "^0.7.0",
+    "serverless-jetpack": "FormidableLabs/serverless-jetpack#feature/trace-deps",
     "serverless-offline": "^5.12.1",
     "serverless-plugin-canary-deployments": "^0.4.8"
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "nodemon": "^2.0.2",
     "serverless": "^1.61.1",
-    "serverless-jetpack": "FormidableLabs/serverless-jetpack#feature/trace-deps",
+    "serverless-jetpack": "^0.10.0",
     "serverless-offline": "^5.12.1",
     "serverless-plugin-canary-deployments": "^0.4.8"
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,33 +1,17 @@
 # CloudFormation output name: `sls-${SERVICE_NAME}-${STAGE}`
 service: sls-${self:custom.service}
 
-package:
-  include:
-    # Root level
-    - "!*"
-    - "package.json"
-    # Source directories
-    - "src/**"
-    - "!.*/**"
-    - "!aws/**"
-    - "!terraform/**"
-    # General exclusions
-    - "!**/.DS_Store"
-    - "!**/yarn.lock"
-    - "!**/package-lock.json"
-    - "!**/node_modules/.yarn-integrity"
-    - "!**/node_modules/.cache/**"
-    # Dependencies
-    - "!**/node_modules/aws-sdk/**"
-    - "!**/node_modules/{@*/*,*}/CHANGELOG.md"
-    - "!**/node_modules/{@*/*,*}/HISTORY.md"
-    - "!**/node_modules/{@*/*,*}/LICENSE"
-    - "!**/node_modules/{@*/*,*}/README.md"
-
 custom:
   service: ${env:SERVICE_NAME}
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
+  jetpack:
+    preInclude:
+      - "!**" # Start with no files at all.
+    trace: false
+      # # Use trace mode for speed and ignore aws-sdk + all deps
+      # ignores:
+      #   - "aws-sdk"
 
 plugins:
   - serverless-jetpack
@@ -164,6 +148,16 @@ functions:
     layers:
       - { Ref: VendorLambdaLayer }
       - { Ref: RepeatLambdaLayer }
+    # Package individually for function-level tracing ignores / options.
+    # Easier general solution is no tracing when layer dependencies, although
+    # tracing is likely faster and slimmer.
+    package:
+      individually: true
+    jetpack:
+      trace: false
+        # ignores:      # Add ignores for things provided by layers.
+        #   - "figlet"  # From VendorLambdaLayer
+        #   - "/opt"    # From RepeatLambdaLayer
 
 ###############################################################################
 # OPTION(layers): Add some layers.
@@ -185,7 +179,7 @@ layers:
     name: sls-${self:custom.service}-${self:custom.stage}-repeat
     package:
       include:
-        - "*.js"
+        - "repeat/*.js"
 
 resources:
   Resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,10 +8,10 @@ custom:
   jetpack:
     preInclude:
       - "!**" # Start with no files at all.
-    trace: false
-      # # Use trace mode for speed and ignore aws-sdk + all deps
-      # ignores:
-      #   - "aws-sdk"
+    trace:
+      # Use trace mode for speed and ignore aws-sdk + all deps
+      ignores:
+        - "aws-sdk"
 
 plugins:
   - serverless-jetpack
@@ -154,10 +154,10 @@ functions:
     package:
       individually: true
     jetpack:
-      trace: false
-        # ignores:      # Add ignores for things provided by layers.
-        #   - "figlet"  # From VendorLambdaLayer
-        #   - "/opt"    # From RepeatLambdaLayer
+      trace:
+        ignores:      # Add ignores for things provided by layers.
+          - "figlet"  # From VendorLambdaLayer
+          - "/opt"    # From RepeatLambdaLayer
 
 ###############################################################################
 # OPTION(layers): Add some layers.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,9 +5125,10 @@ serverless-http@^2.3.0:
   optionalDependencies:
     "@types/aws-lambda" "^8.10.19"
 
-serverless-jetpack@FormidableLabs/serverless-jetpack#feature/trace-deps:
-  version "0.9.0"
-  resolved "https://codeload.github.com/FormidableLabs/serverless-jetpack/tar.gz/07023b0fddc11e59f94e83dfbdafdb75487f44e3"
+serverless-jetpack@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/serverless-jetpack/-/serverless-jetpack-0.10.0.tgz#fef85c265d9f9e84b4d1e4485102a0ff694f464e"
+  integrity sha512-LkK0CrOwd8lRaz+LiA4cTyWAkcxXERx0m+gHEgdvxpF2dzDayOjDxFr6cMITPGYMAd8ZjybTf2LJCjdCk+1HZg==
   dependencies:
     archiver "^3.1.1"
     globby "^9.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,6 +648,25 @@ acorn-jsx@^5.1.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
   integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
+acorn-node@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
+  integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
+  dependencies:
+    acorn "^7.0.0"
+    acorn-walk "^7.0.0"
+    xtend "^4.0.2"
+
+acorn-walk@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
+  integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
+
+acorn@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+
 acorn@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
@@ -788,7 +807,7 @@ archiver@^1.3.0:
     walkdir "^0.0.11"
     zip-stream "^1.1.0"
 
-archiver@^3.0.0:
+archiver@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/archiver/-/archiver-3.1.1.tgz#9db7819d4daf60aec10fe86b16cb9258ced66ea0"
   integrity sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==
@@ -2909,6 +2928,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
@@ -3510,13 +3534,13 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jest-worker@^24.6.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
-  integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
+jest-worker@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.1.0.tgz#75d038bad6fdf58eba0d2ec1835856c497e3907a"
+  integrity sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==
   dependencies:
     merge-stream "^2.0.0"
-    supports-color "^6.1.0"
+    supports-color "^7.0.0"
 
 jmespath@0.15.0:
   version "0.15.0"
@@ -4407,7 +4431,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.2.0, p-limit@^2.2.2:
+p-limit@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
   integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
@@ -4932,6 +4956,13 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.15.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
+  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
+  dependencies:
+    path-parse "^1.0.6"
+
 responselike@1.0.2, responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
@@ -5085,18 +5116,18 @@ serverless-http@^2.3.0:
   optionalDependencies:
     "@types/aws-lambda" "^8.10.19"
 
-serverless-jetpack@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/serverless-jetpack/-/serverless-jetpack-0.7.0.tgz#71ac1526f7f32917f26029936fd7cc5a96424e7a"
-  integrity sha512-YCELQVJm6yFcsnnCFfoVrLaXe9ByRjNSZJqJGjMNiD/fr144dRzEuaYrr36AIqHzES3Go66/goSZ++APopQXpQ==
+serverless-jetpack@FormidableLabs/serverless-jetpack#feature/trace-deps:
+  version "0.9.0"
+  resolved "https://codeload.github.com/FormidableLabs/serverless-jetpack/tar.gz/7ea3fb2c4d4b2b400fbdacba7b07e470fe49b735"
   dependencies:
-    archiver "^3.0.0"
+    archiver "^3.1.1"
     globby "^9.2.0"
     inspectdep "^0.2.0"
-    jest-worker "^24.6.0"
+    jest-worker "^25.1.0"
     make-dir "^3.0.0"
     nanomatch "^1.2.13"
-    p-limit "^2.2.0"
+    p-limit "^2.2.2"
+    trace-deps "^0.1.0"
 
 serverless-offline@^5.12.1:
   version "5.12.1"
@@ -5578,12 +5609,12 @@ supports-color@^5.3.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+supports-color@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
-    has-flag "^3.0.0"
+    has-flag "^4.0.0"
 
 table@^5.2.3:
   version "5.4.6"
@@ -5726,6 +5757,14 @@ touch@^3.1.0:
   integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
   dependencies:
     nopt "~1.0.10"
+
+trace-deps@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.1.0.tgz#2084958d06e97805a81ce7fc1d6a2c79c200606c"
+  integrity sha512-4iVBcuyPehXteYtQfUzBjBuycWosj07VZOjDxm0OAtlHqz8T8t/BELyzAnB04J2cdEfd2MRFqGjfjSCWVX14pA==
+  dependencies:
+    acorn-node "^1.8.2"
+    resolve "^1.15.1"
 
 traverse@^0.6.6:
   version "0.6.6"
@@ -6202,7 +6241,7 @@ xmlbuilder@~9.0.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
-xtend@^4.0.0, xtend@^4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3919,9 +3919,9 @@ make-dir@^1.0.0, make-dir@^1.2.0:
     pify "^3.0.0"
 
 make-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
-  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392"
+  integrity sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==
   dependencies:
     semver "^6.0.0"
 
@@ -4814,10 +4814,19 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.0, readable-stream@^3.0.1, readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.0.1, readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -5118,7 +5127,7 @@ serverless-http@^2.3.0:
 
 serverless-jetpack@FormidableLabs/serverless-jetpack#feature/trace-deps:
   version "0.9.0"
-  resolved "https://codeload.github.com/FormidableLabs/serverless-jetpack/tar.gz/7ea3fb2c4d4b2b400fbdacba7b07e470fe49b735"
+  resolved "https://codeload.github.com/FormidableLabs/serverless-jetpack/tar.gz/07023b0fddc11e59f94e83dfbdafdb75487f44e3"
   dependencies:
     archiver "^3.1.1"
     globby "^9.2.0"
@@ -5127,7 +5136,7 @@ serverless-jetpack@FormidableLabs/serverless-jetpack#feature/trace-deps:
     make-dir "^3.0.0"
     nanomatch "^1.2.13"
     p-limit "^2.2.2"
-    trace-deps "^0.1.0"
+    trace-deps "^0.2.0"
 
 serverless-offline@^5.12.1:
   version "5.12.1"
@@ -5758,10 +5767,10 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-trace-deps@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.1.0.tgz#2084958d06e97805a81ce7fc1d6a2c79c200606c"
-  integrity sha512-4iVBcuyPehXteYtQfUzBjBuycWosj07VZOjDxm0OAtlHqz8T8t/BELyzAnB04J2cdEfd2MRFqGjfjSCWVX14pA==
+trace-deps@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.2.0.tgz#18d3ea1c4c084f214d783ced13de92efda394f6f"
+  integrity sha512-xAFJN6xqjYZFMLqjwosXQnyOTFSuA7g7aysUTPPLxGUl2jE0N5DvcSrjJABXyrCEyo3tP8o26J4Ejr1B1e0RDg==
   dependencies:
     acorn-node "^1.8.2"
     resolve "^1.15.1"


### PR DESCRIPTION
## Status / remaining
- [x] Verify all handlers live in AWS
- [x] Fix trace-deps issue https://github.com/FormidableLabs/aws-lambda-serverless-reference/issues/70
- [x] Update to published jetpack

## Work
- Update `serverless-jetpack` and enable new tracing mode.
- Switch to tighter `preInclude` globbing.

## Testing
The work is currently deployed to `STAGE=sandbox`. Test things out at:

- https://amx4dqzs4j.execute-api.us-east-1.amazonaws.com/sandbox/base/
- https://amx4dqzs4j.execute-api.us-east-1.amazonaws.com/sandbox/xray/
- https://amx4dqzs4j.execute-api.us-east-1.amazonaws.com/sandbox/vpc/
- https://amx4dqzs4j.execute-api.us-east-1.amazonaws.com/sandbox/canary/
- https://amx4dqzs4j.execute-api.us-east-1.amazonaws.com/sandbox/layers/
